### PR TITLE
Fix invalid escape sequences by using raw strings

### DIFF
--- a/cve_prioritizer.py
+++ b/cve_prioritizer.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
         throttle = 1
         if len(cve_list) > 75 and not os.getenv('NIST_API'):
             throttle = 6
-        if not re.match("(CVE|cve-\d{4}-\d+$)", cve):
+        if not re.match(r"(CVE|cve-\d{4}-\d+$)", cve):
             print(f"{cve} Error: CVEs should be provided in the standard format CVE-0000-0000*")
         else:
             sem.acquire()

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -11,7 +11,7 @@ VERBOSE_HEADER = (f"{'CVE-ID':<18}{'PRIORITY':<13}{'EPSS':<9}{'CVSS':<6}{'VERSIO
                   f"{'VENDOR':<18}PRODUCT")+"\n"+("-"*115)
 EPSS_URL = "https://api.first.org/data/v1/epss"
 NIST_BASE_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
-LOGO = """
+LOGO = r"""
 #    ______   ______                         
 #   / ___/ | / / __/                         
 #  / /__ | |/ / _/                           


### PR DESCRIPTION
This request changes 2 strings to raw strings (`r"..."`) to fix SyntaxWarning errors on startup. No functionality is changed