### PR TITLE
Add script from setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,6 @@ dependencies = [
 ]
 requires-python = ">=3.8"
 keywords = ["CVE", "CVSS", "EPSS", "CISA", "Prioritize", "Vulnerability"]
+
+[project.scripts]
+cve-prioritizer = "cve_prioritizer.cve_prioritizer:main"


### PR DESCRIPTION
Fixes

```bash
[...]
  _handle_missing_dynamic(dist, project_table)
/nix/store/sfifx7g499n2xfvs5hzvw3mxinn0i17x-python3.12-setuptools-75.3.0/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:71: _MissingDynamic: `scripts` defined outside of `pyproject.toml` is ignored.
!!

        ********************************************************************************
        The following seems to be defined outside of `pyproject.toml`:

        `scripts = ['cve_prioritizer=cve_prioritizer:main']`

        According to the spec (see the link below), however, setuptools CANNOT
        consider this value unless `scripts` is listed as `dynamic`.

        https://packaging.python.org/en/latest/specifications/pyproject-toml/#declaring-project-metadata-the-project-table

        To prevent this problem, you can list `scripts` under `dynamic` or alternatively
        remove the `[project]` table from your file and rely entirely on other means of
        configuration.
        ********************************************************************************

!!
[...]
```